### PR TITLE
operations interfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     compile("com.squareup.okhttp3:okhttp:4.2.2")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -24,7 +24,6 @@ repositories {
 dependencies {
     compile(kotlin("stdlib"))
     compile("io.titandata:remote-sdk:0.0.11")
-    compile("com.squareup.okhttp3:okhttp:4.2.2")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -5,7 +9,9 @@ plugins {
     `maven-publish`
 
 }
+
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +23,8 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.8")
+    compile("io.titandata:remote-sdk:0.0.10")
+    compile("com.squareup.okhttp3:okhttp:4.2.2")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -19,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     compile("com.google.code.gson:gson:2.8.6")
     compile("com.squareup.okhttp3:okhttp:4.2.2")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
     `maven-publish`
 
 }
+
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +19,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.8")
+    compile("io.titandata:remote-sdk:0.0.10")
     compile("com.google.code.gson:gson:2.8.6")
     compile("com.squareup.okhttp3:okhttp:4.2.2")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/server/src/main/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServer.kt
@@ -55,7 +55,7 @@ class S3WebRemoteServer : ArchiveRemote() {
     /**
      * Fetch a file from the given remote, returning as a response.
      */
-    internal fun getFile(remote: Map<String, Any>, path: String): Response {
+    fun getFile(remote: Map<String, Any>, path: String): Response {
         val url = remote["url"] as String
         val request = Request.Builder().url("$url/$path").build()
         return http.newCall(request).execute()

--- a/server/src/main/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServer.kt
@@ -1,10 +1,16 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.s3web.server
 
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
 import io.titandata.remote.RemoteOperation
-import io.titandata.remote.RemoteServer
+import io.titandata.remote.RemoteOperationType
 import io.titandata.remote.RemoteServerUtil
+import io.titandata.remote.archive.ArchiveRemote
+import java.io.File
 import java.io.IOException
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -20,7 +26,7 @@ import okhttp3.Response
  * The main thing is that it expects to find the same layout as the S3 provider generates, including a "titan" file
  * at the root of the repository that has all the commit metadata.
  */
-class S3WebRemoteServer : RemoteServer {
+class S3WebRemoteServer : ArchiveRemote() {
 
     internal val util = RemoteServerUtil()
     internal val gson = GsonBuilder().create()
@@ -102,14 +108,33 @@ class S3WebRemoteServer : RemoteServer {
     }
 
     override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
-        throw NotImplementedError()
+        // Do nothing
     }
 
     override fun startOperation(operation: RemoteOperation) {
-        throw NotImplementedError()
+        if (operation.type == RemoteOperationType.PUSH) {
+            throw NotImplementedError("push operations are not supported with s3web remotes")
+        }
     }
 
-    override fun syncVolume(operation: RemoteOperation, volumeName: String, volumeDescription: String, volumePath: String, scratchPath: String) {
-        throw NotImplementedError()
+    override fun pullArchive(operation: RemoteOperation, volume: String, archive: File) {
+        val archivePath = "${operation.commitId}/$volume.tar.gz"
+        val response = getFile(operation.remote, archivePath)
+        if (!response.isSuccessful) {
+            throw IOException("failed to get ${operation.remote["url"]}/$archivePath, error code ${response.code}")
+        }
+        response.body!!.byteStream().use { input ->
+            archive.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    override fun pushArchive(operation: RemoteOperation, volume: String, archive: File) {
+        throw NotImplementedError("push operations are not supported with s3web remotes")
+    }
+
+    override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
+        throw NotImplementedError("push operations are not supported with s3web remotes")
     }
 }

--- a/server/src/test/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3web/server/S3WebRemoteServerTest.kt
@@ -51,6 +51,7 @@ class S3WebRemoteServerTest : StringSpec() {
             parameters = emptyMap(),
             operationId = "operation",
             commitId = "commit",
+            commit = null,
             type = RemoteOperationType.PUSH,
             data = null
     )


### PR DESCRIPTION
## Proposed Changes

This adds all the interfaces required by the new remote SDK. While I was here, I also cleaned up some copyright stuff and made it so you could link to libraries in your local maven repository.

## Testing

`gradle build` and verified coverage. Also ran all tests in `titan-server` (including endtoend tests) with new remote.